### PR TITLE
Update the aria labels on the controls, using the media title.

### DIFF
--- a/src/js/listeners.js
+++ b/src/js/listeners.js
@@ -11,6 +11,7 @@ import { off, on, once, toggleListener, triggerEvent } from './utils/events';
 import is from './utils/is';
 import { silencePromise } from './utils/promise';
 import { getAspectRatio, setAspectRatio } from './utils/style';
+import i18n from './utils/i18n';
 
 class Listeners {
   constructor(player) {
@@ -908,6 +909,68 @@ class Listeners {
       'volume',
       false,
     );
+  }
+
+  // Listen for control events - update aria labels
+  ariaLabels() {
+    const { player } = this;
+    const { elements } = player;
+
+    let title;
+
+    // If there's a media title set, use that for the label
+    if (is.string(player.config.title) && !is.empty(player.config.title)) {
+      title = `${player.config.title}`;
+    }
+
+    function updateLabel(target, key) {
+      if (target && title) {
+        target.setAttribute('aria-label', `${i18n.get(key, player.config)}, ${title}`);
+      }
+    }
+
+    // Initial aria-label setup
+    updateLabel(elements.buttons.restart, 'reset');
+    updateLabel(elements.buttons.rewind, 'rewind');
+    updateLabel(elements.buttons.fastForward, 'fastForward');
+    updateLabel(elements.buttons.mute, player.muted ? 'unmute' : 'mute');
+    updateLabel(elements.buttons.download, 'download');
+    updateLabel(elements.buttons.fullscreen, 'enterFullscreen');
+    updateLabel(elements.buttons.pip, 'pip');
+    updateLabel(elements.buttons.airplay, 'airplay');
+    updateLabel(elements.buttons.settings, 'settings');
+    updateLabel(elements.buttons.loop, 'loop');
+    updateLabel(elements.buttons.transcript, 'transcript');
+
+    updateLabel(elements.inputs.seek, 'seek');
+    updateLabel(elements.inputs.volume, 'volume');
+
+    on.call(player, player.media, 'captionsenabled', (event) => {
+      updateLabel(elements.buttons.captions, 'disableCaptions');
+    });
+    on.call(player, player.media, 'captionsdisabled', (event) => {
+      updateLabel(elements.buttons.captions, 'enableCaptions');
+    });
+    on.call(player, player.media, 'descriptionsenabled', (event) => {
+      updateLabel(elements.buttons.descriptions, 'disableDescriptions');
+    });
+    on.call(player, player.media, 'descriptionsdisabled', (event) => {
+      updateLabel(elements.buttons.descriptions, 'enableDescriptions');
+    });
+    on.call(player, player.media, 'volumechange', (event) => {
+      updateLabel(elements.buttons.mute, player.muted ? 'unmute' : 'mute');
+    });
+    on.call(player, player.elements.container, 'enterfullscreen', (event) => {
+      updateLabel(elements.buttons.fullscreen, 'exitFullscreen');
+    });
+    on.call(player, player.elements.container, 'exitfullscreen', (event) => {
+      updateLabel(elements.buttons.fullscreen, 'enterFullscreen');
+    });
+    on.call(player, player.media, 'playing play pause ended emptied timeupdate', (event) => {
+      Array.from(elements.buttons.play || []).forEach((target) => {
+        updateLabel(target, player.playing ? 'pause' : 'play');
+      });
+    });
   }
 }
 

--- a/src/js/ui.js
+++ b/src/js/ui.js
@@ -52,6 +52,7 @@ const ui = {
 
       // Re-attach control listeners
       this.listeners.controls();
+      this.listeners.ariaLabels();
     }
 
     // Remove native controls
@@ -225,7 +226,6 @@ const ui = {
     // Set state
     Array.from(this.elements.buttons.play || []).forEach((target) => {
       Object.assign(target, { pressed: this.playing });
-      target.setAttribute('aria-label', i18n.get(this.playing ? 'pause' : 'play', this.config));
     });
 
     // Only update controls on non timeupdate events


### PR DESCRIPTION
### Link to related issue (if applicable)
https://github.com/Laerdal/plyr/issues/14
### Summary of proposed changes
- Media title used to change the aria labels on the controls
- Listens to media events to update toggle type controls

### Checklist
- [x] Use `develop` as the base branch
- [x] Exclude the gulp build (`/dist` changes) from the PR
- [ ] Test on [supported browsers](https://github.com/sampotts/plyr#browser-support)
