### PR TITLE
Including a function check, to allow IE11 to fall back to using the d…

### DIFF
--- a/src/js/utils/elements.js
+++ b/src/js/utils/elements.js
@@ -246,7 +246,8 @@ export function closest(element, selector) {
     let el = this;
 
     do {
-      if (matches.matches(el, selector)) return el;
+      // matches.matches fails in IE11, including check for temporary fix (will fallback to default fullscreen container)
+      if (matches.matches && matches.matches(el, selector)) return el;
       el = el.parentElement || el.parentNode;
     } while (el !== null && el.nodeType === 1);
     return null;


### PR DESCRIPTION

### Link to related issue (if applicable)
Using a custom fullscreen container fails in IE11 https://github.com/Laerdal/plyr/issues/19
### Summary of proposed changes
- Checks for matches.matches in elements.js to prevent IE11 throwing an error
### Checklist
- [x] Use `develop` as the base branch
- [x] Exclude the gulp build (`/dist` changes) from the PR
- [ ] Test on [supported browsers](https://github.com/sampotts/plyr#browser-support)
