### PR TITLE
Use brand color for tab focus color

### DIFF
--- a/src/sass/settings/colors.scss
+++ b/src/sass/settings/colors.scss
@@ -4,6 +4,7 @@
 
 $plyr-color-main: var(--plyr-color-main, #777) !default;
 $plyr-video-background: var(--plyr-video-background, #fff) !default;
+$plyr-color-brand: var(--plyr-color-brand, #2e7fa1) !default;
 
 // Grayscale
 $plyr-color-gray-900: hsl(216, 15%, 16%) !default;

--- a/src/sass/settings/cosmetics.scss
+++ b/src/sass/settings/cosmetics.scss
@@ -2,4 +2,4 @@
 // Cosmetic
 // ==========================================================================
 
-$plyr-tab-focus-color: var(--plyr-tab-focus-color, #2e7fa1) !default;
+$plyr-tab-focus-color: var(--plyr-tab-focus-color, $plyr-color-brand) !default;


### PR DESCRIPTION
### Summary of proposed changes
Update to style sheets, use $plyr-color-brand for tab focus color
