### PR TITLE
Changed function call to just matches, as matches.matches does not exist

### DIFF
--- a/src/js/utils/elements.js
+++ b/src/js/utils/elements.js
@@ -246,7 +246,7 @@ export function closest(element, selector) {
     let el = this;
 
     do {
-      if (matches.matches(el, selector)) return el;
+      if (matches(el, selector)) return el;
       el = el.parentElement || el.parentNode;
     } while (el !== null && el.nodeType === 1);
     return null;


### PR DESCRIPTION
### Link to related issue (if applicable)
Issue created on official repo
https://github.com/sampotts/plyr/issues/2252

### Summary of proposed changes

- corrected function call to just .matches()
