### PR TITLE
Update aria labels on media events, using the media title.

### DIFF
--- a/src/js/ui.js
+++ b/src/js/ui.js
@@ -53,6 +53,7 @@ const ui = {
 
       // Re-attach control listeners
       this.listeners.controls();
+      this.listeners.ariaLabels();
     }
 
     // Remove native controls
@@ -231,7 +232,6 @@ const ui = {
     // Set state
     Array.from(this.elements.buttons.play || []).forEach((target) => {
       Object.assign(target, { pressed: this.playing });
-      target.setAttribute('aria-label', i18n.get(this.playing ? 'pause' : 'play', this.config));
     });
 
     // Only update controls on non timeupdate events


### PR DESCRIPTION
### Issue

If there are multiple media players on the same page, the label on the controls would not be distinct. This may cause confusion for people using screen readers.

### Summary of proposed changes

The aria labels set on the player controls now include the media title if set.
