### PR TITLE
When in fullscreen and controls are positioned as overlay, move the c…

### DIFF
--- a/src/sass/lib/mixins.scss
+++ b/src/sass/lib/mixins.scss
@@ -65,6 +65,10 @@
     z-index: 3;
   }
 
+  .plyr__captions {
+    margin-bottom: 3rem;
+  }
+
   // Display correct icon
   .plyr__control .icon--exit-fullscreen {
     display: block;


### PR DESCRIPTION
### Issue
Captions are slightly hidden behind controls when in fullscreen
### Summary of proposed changes
When in fullscreen and controls are positioned as overlay, move the captions up so there is no overlap
