### PR TITLE
Helper class added to fullscreen container when fullscreen is active

### DIFF
--- a/src/js/fullscreen.js
+++ b/src/js/fullscreen.js
@@ -148,6 +148,11 @@ class Fullscreen {
       button.pressed = this.active;
     }
 
+    // Update container fullscreen class
+    if (this.player.config.fullscreen.container) {
+      toggleClass(this.player.elements.fullscreen, 'plyr--container-fullscreen-entered', this.active);
+    }
+
     // Always trigger events on the plyr / media element (not a fullscreen container) and let them bubble up
     const target = this.target === this.player.media ? this.target : this.player.elements.container;
     // Trigger an event

--- a/src/sass/states/fullscreen.scss
+++ b/src/sass/states/fullscreen.scss
@@ -32,3 +32,11 @@
   top: 0;
   z-index: 10000000;
 }
+
+// Container used as fullscreen
+.plyr--container-fullscreen-entered {
+  @include plyr-fullscreen-active();
+  .plyr__controls {
+    position: fixed;
+  }
+}


### PR DESCRIPTION
### Issue
There is no way of knowing when a fullscreen container has entered fullscreen or not. So styles cannot be updated.

### Summary of proposed changes
Add helper class to fullscreen container, if using, when fullscreen is active.
