### PR TITLE
Caption line break unicode issue fixed

### DIFF
--- a/src/js/captions.js
+++ b/src/js/captions.js
@@ -359,7 +359,7 @@ const captions = {
       // Empty the container and create a new child element
       emptyElement(this.elements.captions);
       const caption = createElement('span', getAttributesFromSelector(this.config.selectors.caption));
-      caption.innerHTML = content;
+      caption.innerHTML = content.replace(/↵/g, '\n');
       this.elements.captions.appendChild(caption);
 
       // Trigger event


### PR DESCRIPTION
### Summary of proposed changes
Issue: After embedding video from Vimeo with VTT '↵' appears in place of new line.
![image](https://github.com/Laerdal/plyr/assets/35100121/0f24ebe8-179e-4aee-8223-d95f38f16e08)


Fixed:  The line break unicode character replaced ↵ with \n in string in caption subtitle text

