### PR TITLE
ADAPT-1959 Vimeo video subtitle duplicate issue in plyr

### DIFF
--- a/src/js/config/defaults.js
+++ b/src/js/config/defaults.js
@@ -475,6 +475,7 @@ const defaults = {
     title: false,
     speed: true,
     transparent: false,
+    background: true,
     // Custom settings from Plyr
     customControls: true,
     referrerPolicy: null, // https://developer.mozilla.org/en-US/docs/Web/API/HTMLIFrameElement/referrerPolicy


### PR DESCRIPTION
### Captions duplicated for Vimeo

In vimeo video captions showing twice. Because we have plyr caption and vimeo caption. So hide the vimeo caption. In plyr community the suggest this solutions. I have added this link below. It's working fine.

https://github.com/sampotts/plyr/issues/877#issuecomment-906504090

![plyr](https://github.com/Laerdal/plyr/assets/132436261/bdd7d285-21bf-4f8c-9f51-12b7ad3822be)
