### PR TITLE
Vimeo duplicate caption issue fixed and disabled Laerdal Media captions

### DIFF
--- a/src/js/config/defaults.js
+++ b/src/js/config/defaults.js
@@ -474,8 +474,9 @@ const defaults = {
     portrait: false,
     title: false,
     speed: true,
-    transparent: false,
-    background: true,
+    transparent: true,
+    background: false,
+    controls:false,
     // Custom settings from Plyr
     customControls: true,
     referrerPolicy: null, // https://developer.mozilla.org/en-US/docs/Web/API/HTMLIFrameElement/referrerPolicy

--- a/src/js/plugins/vimeo.js
+++ b/src/js/plugins/vimeo.js
@@ -327,10 +327,6 @@ const vimeo = {
       captions.setup.call(player);
     });
 
-    player.embed.on('cuechange', ({ cues = [] }) => {
-      const strippedCues = cues.map((cue) => stripHTML(cue.text));
-      captions.updateCues.call(player, strippedCues);
-    });
 
     player.embed.on('loaded', () => {
       // Assure state and events are updated on autoplay


### PR DESCRIPTION
### Captions duplicated for Vimeo issue fixes are disabled in Media Plyr caption

In Vimeo video captions are showing twice because we have both Plyr captions and Vimeo captions enabled. To resolve this issue, we should hide the Vimeo captions. In the Plyr community, they suggested using the solution 'background=true.' However, this solution is no longer effective. We have since modified the condition, and now Vimeo video captions are played from the Vimeo API and disabled in the Plyr library.

![image](https://github.com/Laerdal/plyr/assets/35100121/bcbd286b-5906-44f8-9b41-823f084fcdcb)

Full Screen :

![image](https://github.com/Laerdal/plyr/assets/35100121/212a574a-5ccb-4b1e-b699-7a2c21e21028)

